### PR TITLE
Updated leptos-use to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codee"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af40247be877a1e3353fb406aa27ab3ef4bd3ff18cef91e75e667bfa3fde701d"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,9 +870,9 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -907,12 +916,13 @@ dependencies = [
 
 [[package]]
 name = "leptos-use"
-version = "0.10.10"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3272d90b77cdbb99e9060f90eb6f5738e56128b2f912db57a50efb006a26e262"
+checksum = "268b9df23d8c68ed0518c39d6f0d3b99fcbe30190a6dce4a7e5f342027ab0033"
 dependencies = [
  "async-trait",
  "cfg-if",
+ "codee",
  "cookie",
  "default-struct-builder",
  "futures-util",
@@ -923,6 +933,7 @@ dependencies = [
  "leptos",
  "paste",
  "thiserror",
+ "unic-langid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -1961,6 +1972,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "unic-langid"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dd9d1e72a73b25e07123a80776aae3e7b0ec461ef94f9151eed6ec88005a44"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5422c1f65949306c99240b81de9f3f15929f5a8bfe05bb44b034cc8bf593e5"
+dependencies = [
+ "tinystr",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,19 +2069,20 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
@@ -2077,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2087,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2100,9 +2130,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "wasm-streams"
@@ -2119,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -20,7 +20,7 @@ leptos = { version = "0.6", features = ["csr"] }
 leptos-chartistry = { path = "../leptos-chartistry" }
 leptos_meta = { version = "0.6", features = ["csr"] }
 leptos_router = { version = "0.6", features = ["csr"] }
-leptos-use = "0.10"
+leptos-use = "0.12"
 log = "0.4"
 strum = { version = "0.26.2", features = ["derive"] }
 web-sys = "0.3"

--- a/leptos-chartistry/Cargo.toml
+++ b/leptos-chartistry/Cargo.toml
@@ -15,6 +15,6 @@ categories = [ "graphics", "gui", "wasm", "web-programming" ]
 [dependencies]
 chrono = "0.4"
 leptos = { version = "0.6" }
-leptos-use = "0.10"
+leptos-use = "0.12"
 log = "0.4"
 web-sys = { version = "0.3", features = ["DomRectReadOnly"] }

--- a/leptos-chartistry/src/use_watched_node.rs
+++ b/leptos-chartistry/src/use_watched_node.rs
@@ -1,8 +1,15 @@
+use std::convert::Infallible;
+
 use crate::bounds::Bounds;
 use leptos::{html::Div, *};
 use leptos_use::{
-    use_element_hover, use_mouse_with_options, use_resize_observer_with_options, UseMouseCoordType,
-    UseMouseEventExtractorDefault, UseMouseOptions, UseMouseSourceType, UseResizeObserverOptions,
+    use_element_hover,
+    use_mouse_with_options,
+    use_resize_observer_with_options,
+    UseMouseCoordType,
+    UseMouseOptions,
+    UseMouseSourceType,
+    UseResizeObserverOptions,
 };
 use web_sys::ResizeObserverBoxOptions;
 
@@ -18,11 +25,13 @@ pub fn use_watched_node(node: NodeRef<Div>) -> UseWatchedNode {
     // Outer chart bounds -- dimensions for our root element inside the document
     // Note <svg> has issues around observing size changes. So wrap in a <div>
     // Note also that the box_ option doesn't seem to work for us so wrap in another <div>
-    let (bounds, set_bounds) = create_signal::<Option<Bounds>>(None);
+    let (bounds, set_bounds) =
+        create_signal::<Option<Bounds>>(None);
     use_resize_observer_with_options(
         node,
         move |entries, _| {
-            let rect = &entries[0].target().get_bounding_client_rect();
+            let rect =
+                &entries[0].target().get_bounding_client_rect();
             let rect = Bounds::new(rect.width(), rect.height());
             set_bounds.set(Some(rect))
         },
@@ -36,7 +45,7 @@ pub fn use_watched_node(node: NodeRef<Div>) -> UseWatchedNode {
     let mouse_page = use_mouse_with_options(
         UseMouseOptions::default()
             .target(node)
-            .coord_type(UseMouseCoordType::<UseMouseEventExtractorDefault>::Page)
+            .coord_type(UseMouseCoordType::<Infallible>::Page)
             .reset_on_touch_ends(true),
     );
 
@@ -52,7 +61,7 @@ pub fn use_watched_node(node: NodeRef<Div>) -> UseWatchedNode {
     let mouse_client = use_mouse_with_options(
         UseMouseOptions::default()
             .target(node)
-            .coord_type(UseMouseCoordType::<UseMouseEventExtractorDefault>::Client)
+            .coord_type(UseMouseCoordType::<Infallible>::Client)
             .reset_on_touch_ends(true),
     );
     let mouse_chart: Signal<_> = create_memo(move |_| {
@@ -92,8 +101,12 @@ pub fn use_watched_node(node: NodeRef<Div>) -> UseWatchedNode {
 
 impl UseWatchedNode {
     // Mouse inside inner chart?
-    pub fn mouse_hover_inner(&self, inner: Memo<Bounds>) -> Signal<bool> {
-        let (mouse_rel, hover) = (self.mouse_chart, self.mouse_chart_hover);
+    pub fn mouse_hover_inner(
+        &self,
+        inner: Memo<Bounds>,
+    ) -> Signal<bool> {
+        let (mouse_rel, hover) =
+            (self.mouse_chart, self.mouse_chart_hover);
         create_memo(move |_| {
             let (x, y) = mouse_rel.get();
             hover.get() && inner.get().contains(x, y)


### PR DESCRIPTION
Hi, I was trying to use this crate but ran into this error when compiling:

error[E0599]: no variant or associated item named `__Nonexhaustive` found for enum `web_sys::NotificationPermission` in the current scope
   --> /home/francis/.cargo/registry/src/index.crates.io-6f17d22bba15001f/leptos-use-0.10.10/src/use_web_notification.rs:451:46
    |
451 |             web_sys::NotificationPermission::__Nonexhaustive => Self::Default,
    |                                              ^^^^^^^^^^^^^^^ variant or associated item not found in `NotificationPermission`

upgrading `leptos-use` from `0.10.10` to `0.12.0` solved it.