### PR TITLE
feat(Cargo.toml): add ssr and csr features and forward them to leptos

### DIFF
--- a/leptos-chartistry/Cargo.toml
+++ b/leptos-chartistry/Cargo.toml
@@ -18,3 +18,7 @@ leptos = "=0.7.0-beta4"
 leptos-use = { git = "https://github.com/Synphonyte/leptos-use.git", branch = "leptos-0.7" }
 log = "0.4"
 web-sys = { version = "0.3", features = ["DomRectReadOnly"] }
+
+[features]
+ssr = ["leptos/ssr", "leptos-use/ssr"]
+csr = ["leptos/csr"]


### PR DESCRIPTION
without these it seems to happen that Wasm code gets compiled into the host binary which leads to errors like this:

```
panicked at $HOME/cargo/registry/src/index.crates.io-6f17d22bba15001f/wasm-bindgen-0.2.93/src/lib.rs:1021:1:
function not implemented on non-wasm32 targets
```