### PR TITLE
chore: update `leptos-use` to version `0.13`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "codee"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d3ad3122b0001c7f140cf4d605ef9a9e2c24d96ab0b4fb4347b76de2425f445"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "collection_literals"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,7 +559,7 @@ dependencies = [
  "js-sys",
  "leptos",
  "leptos-chartistry",
- "leptos-use",
+ "leptos-use 0.12.0",
  "leptos_meta",
  "leptos_router",
  "log",
@@ -1062,7 +1071,7 @@ version = "0.1.7"
 dependencies = [
  "chrono",
  "leptos",
- "leptos-use",
+ "leptos-use 0.13.4",
  "log",
  "web-sys",
 ]
@@ -1075,12 +1084,35 @@ checksum = "268b9df23d8c68ed0518c39d6f0d3b99fcbe30190a6dce4a7e5f342027ab0033"
 dependencies = [
  "async-trait",
  "cfg-if",
- "codee",
+ "codee 0.1.2",
  "cookie",
  "default-struct-builder",
  "futures-util",
  "gloo-timers",
  "gloo-utils",
+ "js-sys",
+ "lazy_static",
+ "leptos",
+ "paste",
+ "thiserror",
+ "unic-langid",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "leptos-use"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "293a4efcd9c2dfc003e6a9ae39763f0d07928a995d531354dbc80276a7e9d53c"
+dependencies = [
+ "cfg-if",
+ "codee 0.2.0",
+ "cookie",
+ "default-struct-builder",
+ "futures-util",
+ "gloo-timers",
  "js-sys",
  "lazy_static",
  "leptos",
@@ -1464,7 +1496,7 @@ dependencies = [
  "console_log",
  "leptos",
  "leptos-chartistry",
- "leptos-use",
+ "leptos-use 0.12.0",
  "leptos_axum",
  "leptos_router",
  "log",

--- a/leptos-chartistry/Cargo.toml
+++ b/leptos-chartistry/Cargo.toml
@@ -15,6 +15,6 @@ categories = [ "graphics", "gui", "wasm", "web-programming" ]
 [dependencies]
 chrono = "0.4"
 leptos = "0.6"
-leptos-use = "0.12"
+leptos-use = "0.13"
 log = "0.4"
 web-sys = { version = "0.3", features = ["DomRectReadOnly"] }


### PR DESCRIPTION
Updates `leptos-use` to most recent stable version.