### PR TITLE
Optimize compile time and rlib size.

### DIFF
--- a/demo/src/pages/examples.rs
+++ b/demo/src/pages/examples.rs
@@ -3,7 +3,7 @@ use crate::{
     use_app_context,
 };
 use leptos::{
-    either::{Either, EitherOf10},
+    either::{Either},
     prelude::*,
 };
 use strum::VariantArray;
@@ -152,66 +152,26 @@ impl Example {
         let de = use_app_context().debug.into();
         let da = load_data();
         match self {
-            Self::Line => Either::Left(EitherOf10::A(view! {
-                <series_line::Example debug=de data=da />
-            })),
-            Self::StackedLine => Either::Left(EitherOf10::B(view! {
-                <series_line_stack::Example debug=de data=da />
-            })),
-            Self::Bar => Either::Left(EitherOf10::C(view! {
-                <series_bar::Example debug=de data=da />
-            })),
-            Self::Legend => Either::Left(EitherOf10::D(view! {
-                <edge_legend::Example debug=de data=da />
-            })),
-            Self::TickLabels => Either::Left(EitherOf10::E(view! {
-                <edge_tick_labels::Example debug=de data=da />
-            })),
-            Self::RotatedLabel => Either::Left(EitherOf10::F(view! {
-                <edge_rotated_label::Example debug=de data=da />
-            })),
-            Self::EdgeLayout => Either::Left(EitherOf10::G(view! {
-                <edge_layout::Example debug=de data=da />
-            })),
-            Self::AxisMarker => Either::Left(EitherOf10::H(view! {
-                <inner_axis_marker::Example debug=de data=da />
-            })),
-            Self::GridLine => Either::Left(EitherOf10::I(view! {
-                <inner_grid_line::Example debug=de data=da />
-            })),
-            Self::GuideLine => Either::Left(EitherOf10::J(view! {
-                <inner_guide_line::Example debug=de data=da />
-            })),
-            Self::InsetLegend => Either::Right(EitherOf10::A(view! {
-                <inner_legend::Example debug=de data=da />
-            })),
-            Self::InnerLayout => Either::Right(EitherOf10::B(view! {
-                <inner_layout::Example debug=de data=da />
-            })),
-            Self::MixedInterpolation => Either::Right(EitherOf10::C(view! {
-                <interpolation_mixed::Example debug=de data=da />
-            })),
-            Self::Stepped => Either::Right(EitherOf10::D(view! {
-                <interpolation_stepped::Example debug=de data=da />
-            })),
-            Self::Tooltip => Either::Right(EitherOf10::E(view! {
-                <feature_tooltip::Example debug=de data=da />
-            })),
-            Self::Colours => Either::Right(EitherOf10::F(view! {
-                <feature_colours::Example debug=de data=da />
-            })),
-            Self::Markers => Either::Right(EitherOf10::G(view! {
-                <feature_markers::Example debug=de data=da />
-            })),
-            Self::Markers2 => Either::Right(EitherOf10::H(view! {
-                <feature_markers_2::Example debug=de data=da />
-            })),
-            Self::LineGradient => Either::Right(EitherOf10::I(view! {
-                <feature_line_gradient::Example debug=de data=da />
-            })),
-            Self::Css => Either::Right(EitherOf10::J(view! {
-                <feature_css::Example debug=de data=da />
-            })),
+            Self::Line => view! {<series_line::Example debug=de data=da />}.into_any(),
+            Self::StackedLine => view! {<series_line_stack::Example debug=de data=da />}.into_any(),
+            Self::Bar => view! {<series_bar::Example debug=de data=da />}.into_any(),
+            Self::Legend => view! {<edge_legend::Example debug=de data=da />}.into_any(),
+            Self::TickLabels => view! {<edge_tick_labels::Example debug=de data=da />}.into_any(),
+            Self::RotatedLabel => view! {<edge_rotated_label::Example debug=de data=da />}.into_any(),
+            Self::EdgeLayout => view! {<edge_layout::Example debug=de data=da />}.into_any(),
+            Self::AxisMarker => view! {<inner_axis_marker::Example debug=de data=da />}.into_any(),
+            Self::GridLine => view! {<inner_grid_line::Example debug=de data=da />}.into_any(),
+            Self::GuideLine => view! {<inner_guide_line::Example debug=de data=da />}.into_any(),
+            Self::InsetLegend => view! {<inner_legend::Example debug=de data=da />}.into_any(),
+            Self::InnerLayout => view! {<inner_layout::Example debug=de data=da />}.into_any(),
+            Self::MixedInterpolation => view! {<interpolation_mixed::Example debug=de data=da />}.into_any(),
+            Self::Stepped => view! {<interpolation_stepped::Example debug=de data=da />}.into_any(),
+            Self::Tooltip => view! {<feature_tooltip::Example debug=de data=da />}.into_any(),
+            Self::Colours => view! {<feature_colours::Example debug=de data=da />}.into_any(),
+            Self::Markers => view! {<feature_markers::Example debug=de data=da />}.into_any(),
+            Self::Markers2 => view! {<feature_markers_2::Example debug=de data=da />}.into_any(),
+            Self::LineGradient => view! {<feature_line_gradient::Example debug=de data=da />}.into_any(),
+            Self::Css => view! {<feature_css::Example debug=de data=da />}.into_any(),
         }
     }
 }

--- a/leptos-chartistry/src/chart.rs
+++ b/leptos-chartistry/src/chart.rs
@@ -216,7 +216,7 @@ pub fn Chart<T: Send + Sync + 'static, X: Tick, Y: Tick>(
             style="overflow: visible;">
             <DebugRect label="Chart" debug=debug />
             <Show when=move || have_dimensions.get() fallback=|| view!(<p>"Loading..."</p>)>
-                <RenderChart
+                {view!{<RenderChart
                     watch=watch.clone()
                     pre_state=pre.clone()
                     aspect_ratio=calc
@@ -226,7 +226,7 @@ pub fn Chart<T: Send + Sync + 'static, X: Tick, Y: Tick>(
                     left=left.clone()
                     inner=inner.clone()
                     tooltip=tooltip.clone()
-                />
+                />}.into_any()}
             </Show>
         </div>
     }
@@ -270,14 +270,16 @@ fn RenderChart<X: Tick, Y: Tick>(
     // Render edges
     let edges = edges
         .into_iter()
-        .map(|r| r.render(state.clone()))
-        .collect_view();
+        .map(|r| r.render(state.clone()).into_any())
+        .collect_view()
+        .into_any();
 
     // Inner
     let inner = inner
         .into_iter()
-        .map(|opt| opt.into_use(&state).render(state.clone()))
-        .collect_view();
+        .map(|opt| opt.into_use(&state).render(state.clone()).into_any())
+        .collect_view()
+        .into_any();
 
     let outer = state.layout.outer;
     view! {
@@ -290,10 +292,11 @@ fn RenderChart<X: Tick, Y: Tick>(
             <CommonDefs />
             {inner}
             {edges}
-            <RenderData state=state.clone() />
+            {view!{<RenderData state=state.clone() />}.into_any()}
         </svg>
         <Tooltip tooltip=tooltip state=state />
     }
+    .into_any()
 }
 
 #[component]

--- a/leptos-chartistry/src/colours/scheme.rs
+++ b/leptos-chartistry/src/colours/scheme.rs
@@ -1,5 +1,5 @@
 use super::Colour;
-use leptos::{either::Either, prelude::*};
+use leptos::prelude::*;
 
 /// A gradient of colours. Maps to a [ColourScheme]
 pub type SequentialGradient = (Colour, &'static [Colour]);
@@ -117,15 +117,16 @@ pub fn LinearGradientSvg(
             {move || scheme.get().stops(range_y.get().unwrap_or_default())}
         </linearGradient>
     }
+    .into_any()
 }
 
 impl ColourScheme {
     fn stops(&self, range_y: (f64, f64)) -> impl IntoView {
         // TODO: collect more colour scheme uses and convert schemes into an enum / trait
         if self.zero.is_some() {
-            Either::Left(self.diverging_stops(range_y))
+            self.diverging_stops(range_y).into_any()
         } else {
-            Either::Right(self.sequential_stops())
+            self.sequential_stops().into_any()
         }
     }
 

--- a/leptos-chartistry/src/debug.rs
+++ b/leptos-chartistry/src/debug.rs
@@ -28,7 +28,7 @@ pub fn DebugRect(
                         stroke="red"
                         stroke-width=1
                     />
-                }
+                }.into_any()
             })
             .collect_view();
         Either::Right(rects)

--- a/leptos-chartistry/src/inner/legend.rs
+++ b/leptos-chartistry/src/inner/legend.rs
@@ -80,5 +80,5 @@ pub(super) fn InsetLegend<X: Tick, Y: Tick>(
         <g class="_chartistry_legend_inset">
             <Legend legend=legend edge=edge bounds=bounds state=state />
         </g>
-    }
+    }.into_any()
 }

--- a/leptos-chartistry/src/inner/mod.rs
+++ b/leptos-chartistry/src/inner/mod.rs
@@ -8,7 +8,7 @@ use axis_marker::AxisMarker;
 use grid_line::{XGridLine, YGridLine};
 use guide_line::{XGuideLine, YGuideLine};
 use legend::InsetLegend;
-use leptos::{either::EitherOf6, prelude::*};
+use leptos::{prelude::*};
 
 /// Inner layout options for a [Chart](crate::Chart). See [IntoInner](trait@IntoInner) for details.
 #[derive(Clone)]
@@ -59,24 +59,12 @@ impl<X: Tick, Y: Tick> InnerLayout<X, Y> {
 impl<X: Tick, Y: Tick> UseInner<X, Y> {
     pub(super) fn render(self, state: State<X, Y>) -> impl IntoView {
         match self {
-            Self::AxisMarker(inner) => EitherOf6::A(view! {
-                <AxisMarker marker=inner state=state />
-            }),
-            Self::XGridLine(inner) => EitherOf6::B(view! {
-                <XGridLine line=inner state=state />
-            }),
-            Self::YGridLine(inner) => EitherOf6::C(view! {
-                <YGridLine line=inner state=state />
-            }),
-            Self::XGuideLine(inner) => EitherOf6::D(view! {
-                <XGuideLine line=inner state=state />
-            }),
-            Self::YGuideLine(inner) => EitherOf6::E(view! {
-                <YGuideLine line=inner state=state />
-            }),
-            Self::Legend(inner) => EitherOf6::F(view! {
-                <InsetLegend legend=inner state=state />
-            }),
+            Self::AxisMarker(inner) => view! {<AxisMarker marker=inner state=state />}.into_any(),
+            Self::XGridLine(inner) => view! {<XGridLine line=inner state=state />}.into_any(),
+            Self::YGridLine(inner) => view! {<YGridLine line=inner state=state />}.into_any(),
+            Self::XGuideLine(inner) => view! {<XGuideLine line=inner state=state />}.into_any(),
+            Self::YGuideLine(inner) => view! {<YGuideLine line=inner state=state />}.into_any(),
+            Self::Legend(inner) => view! {<InsetLegend legend=inner state=state />}.into_any(),
         }
     }
 }

--- a/leptos-chartistry/src/layout/legend.rs
+++ b/leptos-chartistry/src/layout/legend.rs
@@ -7,7 +7,7 @@ use crate::{
     state::{PreState, State},
     Padding, Tick,
 };
-use leptos::{either::Either, prelude::*};
+use leptos::{prelude::*};
 
 /// Builds a legend for the chart [series](crate::Series). Orientated along the axis of its placed edge. Drawn in HTML.
 #[derive(Clone, Debug, PartialEq)]
@@ -103,13 +103,9 @@ pub(crate) fn Legend<X: Tick, Y: Tick>(
     let html = move || {
         let edge = edge.get();
         let body = if edge.is_horizontal() {
-            Either::Left(view! {
-                <HorizontalBody series=series state=state.clone() />
-            })
+            view! {<HorizontalBody series=series state=state.clone() />}.into_any()
         } else {
-            Either::Right(view! {
-                <VerticalBody series=series state=state.clone() />
-            })
+            view! {<VerticalBody series=series state=state.clone() />}.into_any()
         };
         view! {
             <div
@@ -124,7 +120,7 @@ pub(crate) fn Legend<X: Tick, Y: Tick>(
                     </tbody>
                 </table>
             </div>
-        }
+        }.into_any()
     };
 
     view! {

--- a/leptos-chartistry/src/layout/mod.rs
+++ b/leptos-chartistry/src/layout/mod.rs
@@ -11,7 +11,7 @@ use crate::{
     state::{PreState, State},
     Tick,
 };
-use leptos::{either::EitherOf3, prelude::*};
+use leptos::{prelude::*};
 
 /// All possible layout options for an edge of a [Chart](crate::Chart). See [IntoEdge](trait@IntoEdge) for details.
 #[derive(Clone)]
@@ -45,15 +45,9 @@ impl UseLayout {
         state: State<X, Y>,
     ) -> impl IntoView {
         match self {
-            Self::Legend(inner) => EitherOf3::A(view! {
-                <legend::Legend legend=inner edge=edge bounds=bounds state=state />
-            }),
-            Self::RotatedLabel(inner) => EitherOf3::B(view! {
-                <rotated_label::RotatedLabel label=inner edge=edge bounds=bounds state=state />
-            }),
-            Self::TickLabels(inner) => EitherOf3::C(view! {
-                <tick_labels::TickLabels ticks=inner edge=edge bounds=bounds state=state />
-            }),
+            Self::Legend(inner) => view! {<legend::Legend legend=inner edge=edge bounds=bounds state=state />}.into_any(),
+            Self::RotatedLabel(inner) => view! {<rotated_label::RotatedLabel label=inner edge=edge bounds=bounds state=state />}.into_any(),
+            Self::TickLabels(inner) => view! {<tick_labels::TickLabels ticks=inner edge=edge bounds=bounds state=state />}.into_any(),
         }
     }
 }

--- a/leptos-chartistry/src/overlay/tooltip.rs
+++ b/leptos-chartistry/src/overlay/tooltip.rs
@@ -290,7 +290,7 @@ pub(crate) fn Tooltip<X: Tick, Y: Tick>(
                         {y_value}
                     </td>
                 </tr>
-            }
+            }.into_any()
         }
     };
 
@@ -322,5 +322,5 @@ pub(crate) fn Tooltip<X: Tick, Y: Tick>(
                 </table>
             </aside>
         </Show>
-    }
+    }.into_any()
 }

--- a/leptos-chartistry/src/series/bar.rs
+++ b/leptos-chartistry/src/series/bar.rs
@@ -211,9 +211,10 @@ pub fn RenderBar<X: Tick, Y: Tick>(
                             y=y
                             width=group_width_inner
                             height=height />
-                    }
+                    }.into_any()
                 })
-                .collect::<Vec<_>>()
+                .collect_view()
+                .into_any()
         })
     };
     view! {

--- a/leptos-chartistry/src/series/line/marker.rs
+++ b/leptos-chartistry/src/series/line/marker.rs
@@ -1,6 +1,6 @@
 use super::UseLine;
 use crate::colours::Colour;
-use leptos::{either::EitherOf7, prelude::*};
+use leptos::prelude::*;
 
 // Scales our marker (drawn -1 to 1) to a 1.0 line width
 const WIDTH_TO_MARKER: f64 = 8.0;
@@ -115,7 +115,7 @@ pub(super) fn LineMarkers(line: UseLine, positions: Signal<Vec<(f64, f64)>>) -> 
 
         // Avoid the cost of empty nodes
         if shape != MarkerShape::None {
-            return vec![].collect_view();
+            return view!{}.into_any();
         };
 
         positions.with(|positions| {
@@ -132,7 +132,7 @@ pub(super) fn LineMarkers(line: UseLine, positions: Signal<Vec<(f64, f64)>>) -> 
                             line_width=line_width />
                     }
                 })
-                .collect_view()
+                .collect_view().into_any()
         })
     };
 
@@ -144,7 +144,7 @@ pub(super) fn LineMarkers(line: UseLine, positions: Signal<Vec<(f64, f64)>>) -> 
             class="_chartistry_line_markers">
             {markers}
         </g>
-    }
+    }.into_any()
 }
 
 /// Renders the marker shape in a square. They should all be similar in size and not just extend to the edge e.g., square is a rotated diamond.
@@ -158,9 +158,9 @@ fn MarkerShape(
 ) -> impl IntoView {
     let radius = diameter / 2.0;
     match shape {
-        MarkerShape::None => EitherOf7::A(()),
+        MarkerShape::None => ().into_any(),
 
-        MarkerShape::Circle => EitherOf7::B(view! {
+        MarkerShape::Circle => view! {
             // Radius to fit inside our square / diamond -- not the viewbox rect
             <circle
                 cx=x
@@ -168,32 +168,32 @@ fn MarkerShape(
                 r=(45.0_f64).to_radians().sin() * radius
                 paint-order="stroke fill"
             />
-        }),
+        }.into_any(),
 
-        MarkerShape::Square => EitherOf7::C(view! {
+        MarkerShape::Square => view! {
             <Diamond x=x y=y radius=radius rotate=45 />
-        }),
+        }.into_any(),
 
-        MarkerShape::Diamond => EitherOf7::D(view! {
+        MarkerShape::Diamond => view! {
             <Diamond x=x y=y radius=radius />
-        }),
+        }.into_any(),
 
-        MarkerShape::Triangle => EitherOf7::E(view! {
+        MarkerShape::Triangle => view! {
             <polygon
                 points=format!("{},{} {},{} {},{}",
                     x, y - radius,
                     x - radius, y + radius,
                     x + radius, y + radius)
                 paint-order="stroke fill"/>
-        }),
+        }.into_any(),
 
-        MarkerShape::Plus => EitherOf7::F(view! {
+        MarkerShape::Plus => view! {
             <PlusPath x=x y=y diameter=diameter leg=line_width />
-        }),
+        }.into_any(),
 
-        MarkerShape::Cross => EitherOf7::G(view! {
+        MarkerShape::Cross => view! {
             <PlusPath x=x y=y diameter=diameter leg=line_width rotate=45 />
-        }),
+        }.into_any(),
     }
 }
 

--- a/leptos-chartistry/src/series/line/mod.rs
+++ b/leptos-chartistry/src/series/line/mod.rs
@@ -231,5 +231,5 @@ pub fn RenderLine<X: Tick, Y: Tick>(
             <path d=path fill="none" />
             <marker::LineMarkers line=line positions=markers />
         </g>
-    }
+    }.into_any()
 }

--- a/leptos-chartistry/src/series/use_data/mod.rs
+++ b/leptos-chartistry/src/series/use_data/mod.rs
@@ -134,5 +134,5 @@ pub fn RenderData<X: Tick, Y: Tick>(state: State<X, Y>) -> impl IntoView {
                 <RenderUseY use_y=use_y.clone() state=state.clone() positions=mk_svg_coords(use_y.id) />
             </For>
         </g>
-    }
+    }.into_any()
 }

--- a/leptos-chartistry/src/series/use_y.rs
+++ b/leptos-chartistry/src/series/use_y.rs
@@ -55,17 +55,15 @@ pub(super) fn RenderUseY<X: Tick, Y: Tick>(
 ) -> impl IntoView {
     let desc = use_y.desc.clone();
     match desc {
-        UseYDesc::Line(line) => Either::Left(view! {
+        UseYDesc::Line(line) => view! {
             <RenderLine
                 use_y=use_y
                 line=line
                 data=state.pre.data
                 positions=positions
                 markers=positions />
-        }),
-        UseYDesc::Bar(bar) => Either::Right(view! {
-            <RenderBar bar=bar state=state positions=positions />
-        }),
+        }.into_any(),
+        UseYDesc::Bar(bar) => view! {<RenderBar bar=bar state=state positions=positions />}.into_any(),
     }
 }
 
@@ -79,7 +77,7 @@ pub fn Snippet<X: Tick, Y: Tick>(series: UseY, state: State<X, Y>) -> impl IntoV
             <Taster series=series state=state />
             {name}
         </div>
-    }
+    }.into_any()
 }
 
 #[component]
@@ -129,5 +127,5 @@ fn Taster<X: Tick, Y: Tick>(series: UseY, state: State<X, Y>) -> impl IntoView {
             <DebugRect label="taster" debug=debug bounds=vec![bounds.into()] />
             {desc}
         </svg>
-    }
+    }.into_any()
 }


### PR DESCRIPTION
Due to the way leptos works the typenames ends up being massive which in turn creates massive rlib files for the linker to chew through. In the case of the demo project the rlib file went from >500MB to around 91MB which also significantly speeds up incremental builds as linking becomes the dominating part of the compilation time.

The way to alleviate this is by sprinkling in some strategic `into_any()` usages at various points which basically type erases large children names.

On my system this has taken incremental compile times of demo project (using `trunk build`) to about 3.5s from 4.5s when reordering two `Route` elements in `app.rs`.
However, the real gains are observed in my project where the rlib size would increase to a gigantic 5GB which in turn would trigger this linker bug and in turn make the project uncompilable: https://github.com/rust-lang/rust/issues/130729.
With this fix the rlib sits at 1.3GB.