### PR TITLE
Generic chart data type

### DIFF
--- a/leptos-chartistry/src/chart.rs
+++ b/leptos-chartistry/src/chart.rs
@@ -119,6 +119,7 @@ pub fn Chart<T: Send + Sync + 'static, X: Tick, Y: Tick>(
     /// # #[component]
     /// # fn DebugComponent() -> impl IntoView {
     /// let (debug, set_debug) = signal(true);
+    /// # let data = Signal::<Vec<(f64, f64)>>::default();
     /// view! {
     ///     <p>
     ///         <label>
@@ -133,7 +134,7 @@ pub fn Chart<T: Send + Sync + 'static, X: Tick, Y: Tick>(
     ///         // ... fill in the rest of your props
     /// #       aspect_ratio=AspectRatio::from_outer_ratio(600.0, 300.0)
     /// #       series=Series::new(|(x, _): &(f64, f64)| *x).line(|(_, y): &(f64, f64)| *y)
-    /// #       data=Signal::default()
+    /// #       data=data
     ///     />
     /// }
     /// # }

--- a/leptos-chartistry/src/series/use_data/mod.rs
+++ b/leptos-chartistry/src/series/use_data/mod.rs
@@ -25,7 +25,7 @@ pub struct UseData<X: Tick, Y: Tick> {
 impl<X: Tick, Y: Tick> UseData<X, Y> {
     pub fn new<T: Send + Sync + 'static>(
         series: Series<T, X, Y>,
-        data: Signal<Vec<T>>,
+        data: Signal<impl AsRef<[T]> + Send + Sync + 'static>,
     ) -> UseData<X, Y> {
         let lines = series.to_use_lines();
 
@@ -42,7 +42,7 @@ impl<X: Tick, Y: Tick> UseData<X, Y> {
                             .into_iter()
                             .map(|(use_y, get_y)| (use_y.id, get_y))
                             .collect(),
-                        data,
+                        data.as_ref(),
                     )
                 })
             })


### PR DESCRIPTION
This allows to use any type that implements `AsRef<[T]>` as the chart data, instead of just `Vec<T>`.

This fixes #49, as shown in this minimal example:

```rust
struct DataSlice<T> {
    data: Vec<T>,
    start: usize,
    end: usize,
}
impl<T> AsRef<[T]> for DataSlice<T> {
    fn as_ref(&self) -> &[T] {
        &self.data[self.start..self.end]
    }
}

struct MyData { x: f64, y: f64 }

let data: RwSignal<DataSlice<MyData>> = /* ... */;
// Change the display range without cloning all the data:
// data.write().start = ...;
// data.write().end = ...;

let series =  Series::new(|data: &MyData| data.x).line(Line::new(|data: &MyData| data.y);

<Chart
     aspect_ratio=/* ... */
     series=series
     data=data
    /* ... */
  />
```

NB: This is a breaking change, although it was designed to require minimal changes to user code.